### PR TITLE
import lal ligotimegps in lsctables as reported by Tito

### DIFF
--- a/glue/ligolw/lsctables.py
+++ b/glue/ligolw/lsctables.py
@@ -41,11 +41,8 @@ from glue import git_version
 from glue import iterutils
 from glue import offsetvector
 from glue import segments
-try:
-	from pylal.xlal.datatypes.ligotimegps import LIGOTimeGPS
-except ImportError:
-	# pylal is optional
-	from glue.lal import LIGOTimeGPS
+from lal import LIGOTimeGPS
+
 from . import ligolw
 from . import table
 from . import types as ligolwtypes

--- a/setup.py
+++ b/setup.py
@@ -171,8 +171,6 @@ setup(
     ],
   data_files = [
     ( 'etc', [ 
-        os.path.join('etc','glue-user-env.sh'),
-        os.path.join('etc','glue-user-env.csh'),
         os.path.join('etc','ligolw.xsl'),
         os.path.join('etc','ligolw.js'),
         os.path.join('etc','ligolw_dtd.txt') 


### PR DESCRIPTION
Use lal (swig) LIGOTimeGPS in lsctables.py and not the pylal or glue.lal ones. This (I hope) was the last blocker that prevented running the workflows against master after switching to lal's LIGOTimeGPS object internally for segment handling. 