### PR TITLE
E@H: initialize segments_Segment_Type.tp_base and segments_SegmentLis…

### DIFF
--- a/src/segments/segment.c
+++ b/src/segments/segment.c
@@ -421,7 +421,6 @@ static struct PyMethodDef methods[] = {
 
 PyTypeObject segments_Segment_Type = {
 	PyObject_HEAD_INIT(NULL)
-	.tp_base = &PyTuple_Type,
 	.tp_as_number = &as_number,
 	.tp_as_sequence = &as_sequence,
 	.tp_doc =

--- a/src/segments/segmentlist.c
+++ b/src/segments/segmentlist.c
@@ -1346,7 +1346,6 @@ static struct PyMethodDef methods[] = {
 
 PyTypeObject segments_SegmentList_Type = {
 	PyObject_HEAD_INIT(NULL)
-	.tp_base = &PyList_Type,
 	.tp_as_number = &as_number,
 	.tp_as_sequence = &as_sequence,
 	.tp_doc =

--- a/src/segments/segments.c
+++ b/src/segments/segments.c
@@ -74,6 +74,7 @@ void init__segments(void)
 	 * unhappy with that.
 	 */
 
+	segments_Segment_Type.tp_base = &PyTuple_Type;
 	if(!segments_Segment_Type.tp_hash)
 		segments_Segment_Type.tp_hash = PyTuple_Type.tp_hash;
 	if(PyType_Ready(&segments_Segment_Type) < 0)
@@ -87,6 +88,7 @@ void init__segments(void)
 	 * Create segmentlist class
 	 */
 
+	segments_SegmentList_Type.tp_base = &PyList_Type;
 	if(PyType_Ready(&segments_SegmentList_Type) < 0)
 		return;
 	Py_INCREF(&segments_SegmentList_Type);


### PR DESCRIPTION
…t_Type.tp_base at run time

- In Python on Windows, &PyTuple_Type and &PyList_Type aren't known at compile time,
  so one gets an 'initializer is not constant' error when compiling PyCBC-GLUE there.